### PR TITLE
refactor!: Introduce Slugify trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Build Status](https://badgers.space/github/checks/rossmacarthur/pulldown-cmark-toc/trunk?label=build)](https://github.com/rossmacarthur/pulldown-cmark-toc/actions/workflows/build.yaml?branch=trunk)
 
 Generate a table of contents from a Markdown document.
+By default the heading anchor calculation (aka the "slugification")
+is done in a way that attempts to mimic GitHub's (undocumented) behavior.
 
 ## Getting started
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 //! Generate a table of contents from a Markdown document.
 //!
+//! By default the heading anchor calculation (aka the "slugification")
+//! is done in a way that attempts to mimic GitHub's (undocumented) behavior.
+//! (Though you can customize this with your own [`slug::Slugify`] implementation).
+//!
 //! # Examples
 //!
 //! ```

--- a/src/render.rs
+++ b/src/render.rs
@@ -7,6 +7,8 @@ use std::ops::RangeInclusive;
 
 use pulldown_cmark::{Event, HeadingLevel, Tag};
 
+use crate::slug::{GitHubSlugifier, Slugify};
+
 /// Which symbol to use when rendering Markdown list items.
 pub enum ItemSymbol {
     /// `-`
@@ -32,6 +34,7 @@ pub struct Options {
     pub(crate) item_symbol: ItemSymbol,
     pub(crate) levels: RangeInclusive<HeadingLevel>,
     pub(crate) indent: usize,
+    pub(crate) slugifier: Box<dyn Slugify>,
 }
 
 pub(crate) fn to_cmark<'a, I, E>(events: I) -> String
@@ -73,6 +76,7 @@ impl Default for Options {
             item_symbol: ItemSymbol::Hyphen,
             levels: (HeadingLevel::H1..=HeadingLevel::H6),
             indent: 2,
+            slugifier: Box::new(GitHubSlugifier::default()),
         }
     }
 }
@@ -96,6 +100,13 @@ impl Options {
     #[must_use]
     pub fn indent(mut self, indent: usize) -> Self {
         self.indent = indent;
+        self
+    }
+
+    /// The slugifier to use for the heading anchors.
+    #[must_use]
+    pub fn slugifier(mut self, slugifier: Box<dyn Slugify>) -> Self {
+        self.slugifier = slugifier;
         self
     }
 }

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -1,0 +1,77 @@
+use std::{borrow::Cow, collections::HashMap};
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// A trait to specify the anchor calculation.
+pub trait Slugify {
+    fn slugify<'a>(&mut self, str: &'a str) -> Cow<'a, str>;
+}
+
+/// A slugifier that attempts to mimic GitHub's behavior.
+///
+/// Unfortunately GitHub's behavior is not documented anywhere by GitHub.
+/// This should really be part of the [GitHub Flavored Markdown Spec][gfm]
+/// but alas it's not. And there also does not appear to be a public issue
+/// tracker for the spec where that issue could be raised.
+///
+/// [gfm]: https://github.github.com/gfm/
+#[derive(Default)]
+pub struct GitHubSlugifier {
+    counts: HashMap<String, i32>,
+}
+
+impl Slugify for GitHubSlugifier {
+    fn slugify<'a>(&mut self, str: &'a str) -> Cow<'a, str> {
+        static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"[^\w\- ]").unwrap());
+        let anchor = RE
+            .replace_all(&str.to_ascii_lowercase().replace(' ', "-"), "")
+            .into_owned();
+
+        let i = self
+            .counts
+            .entry(anchor.clone())
+            .and_modify(|i| *i += 1)
+            .or_insert(0);
+
+        match *i {
+            0 => anchor,
+            i => format!("{}-{}", anchor, i),
+        }
+        .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::slug::{GitHubSlugifier, Slugify};
+    use crate::Heading;
+    use pulldown_cmark::CowStr::Borrowed;
+    use pulldown_cmark::Event::{Code, Text};
+    use pulldown_cmark::{HeadingLevel, Parser};
+
+    #[test]
+    fn heading_anchor_with_code() {
+        let heading = Heading {
+            events: vec![Code(Borrowed("Another")), Text(Borrowed(" heading"))],
+            level: HeadingLevel::H1,
+        };
+        assert_eq!(
+            GitHubSlugifier::default().slugify(&heading.text()),
+            "another-heading"
+        );
+    }
+
+    #[test]
+    fn heading_anchor_with_links() {
+        let events = Parser::new("Here [TOML](https://toml.io)").collect();
+        let heading = Heading {
+            events,
+            level: HeadingLevel::H1,
+        };
+        assert_eq!(
+            GitHubSlugifier::default().slugify(&heading.text()),
+            "here-toml"
+        );
+    }
+}


### PR DESCRIPTION
Please refer to the commit messages for an explanation of the changes.

The important part is quoted here:

> This is a breaking change since it removes the `Heading::anchor`.
>But that's a good thing anyway since the method previously returned
> wrong anchors on duplicate headings (see #4).

If you like these changes, please preserve the commits on merge (e.g. by merging via rebase).

Resolves #3, resolves #4 and resolves #5.