### PR TITLE
chore: Tweak keywords in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Generate a table of contents from a Markdown document."
 readme = "README.md"
 repository = "https://github.com/rossmacarthur/pulldown-cmark-toc"
 license = "MIT OR Apache-2.0"
-keywords = ["markdown", "commonmark", "table", "contents"]
+keywords = ["toc", "markdown", "commonmark", "pulldown-cmark", "github"]
 categories = ["text-processing"]
 
 [dependencies]


### PR DESCRIPTION
The keywords "table" and "contents" on their own don't refer to a "table of contents", it's better to have "toc" as a keyword. Let's also add "github" as a keyword since this crate also implements the GitHubSlugifier, and "pulldown-cmark" since it's relevant.