### PR TITLE
Upgrade pulldown-cmark to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulldown-cmark-toc"
-version = "0.3.0"
+version = "0.4.0-dev"
 authors = ["Ross MacArthur <ross@macarthur.io>"]
 edition = "2018"
 description = "Generate a table of contents from a Markdown document."
@@ -12,5 +12,5 @@ categories = ["text-processing"]
 
 [dependencies]
 once_cell = "1.18.0"
-pulldown-cmark = { version = "0.9.3", default-features = false }
+pulldown-cmark = { version = "0.10.0", default-features = false }
 regex = "1.9.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulldown-cmark-toc"
-version = "0.4.0-dev"
+version = "0.4.0"
 authors = ["Ross MacArthur <ross@macarthur.io>"]
 edition = "2018"
 description = "Generate a table of contents from a Markdown document."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulldown-cmark-toc"
-version = "0.4.0"
+version = "0.3.0"
 authors = ["Ross MacArthur <ross@macarthur.io>"]
 edition = "2018"
 description = "Generate a table of contents from a Markdown document."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use std::fmt::Write;
 use std::slice::Iter;
 
 pub use pulldown_cmark::HeadingLevel;
-use pulldown_cmark::{Event, Options as CmarkOptions, Parser, Tag};
+use pulldown_cmark::{Event, Options as CmarkOptions, Parser, Tag, TagEnd};
 
 pub use render::{ItemSymbol, Options};
 pub use slug::{GitHubSlugifier, Slugify};
@@ -127,13 +127,13 @@ impl<'a> TableOfContents<'a> {
         for event in events {
             let event = event.borrow();
             match event {
-                Event::Start(Tag::Heading(level, _, _)) => {
+                Event::Start(Tag::Heading { level, .. }) => {
                     current = Some(Heading {
                         events: Vec::new(),
                         level: *level,
                     });
                 }
-                Event::End(Tag::Heading(level, _, _)) => {
+                Event::End(TagEnd::Heading(level)) => {
                     let heading = current.take().unwrap();
                     assert_eq!(heading.level, *level);
                     headings.push(heading);

--- a/src/render.rs
+++ b/src/render.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::fmt::Write;
 use std::ops::RangeInclusive;
 
-use pulldown_cmark::{Event, HeadingLevel, Tag};
+use pulldown_cmark::{Event, HeadingLevel, Tag, TagEnd};
 
 use crate::slug::{GitHubSlugifier, Slugify};
 
@@ -46,8 +46,8 @@ where
     for event in events {
         let event = event.borrow();
         match event {
-            Event::Start(Tag::Emphasis) | Event::End(Tag::Emphasis) => buf.push('*'),
-            Event::Start(Tag::Strong) | Event::End(Tag::Strong) => buf.push_str("**"),
+            Event::Start(Tag::Emphasis) | Event::End(TagEnd::Emphasis) => buf.push('*'),
+            Event::Start(Tag::Strong) | Event::End(TagEnd::Strong) => buf.push_str("**"),
             Event::Text(s) => buf.push_str(s),
             Event::Code(s) => {
                 buf.push('`');


### PR DESCRIPTION
Increases the version of pulldown-cmark to 0.10.0 and resolves breaking changes caused by [pulldown-cmark #517](https://github.com/pulldown-cmark/pulldown-cmark/pull/517) and [pulldown-cmark #638](https://github.com/pulldown-cmark/pulldown-cmark/pull/638).