### PR TITLE
Bump pulldown-cmark to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce76ce678ffc8e5675b22aa1405de0b7037e2fdf8913fea40d1926c6fe1e6e7"
+checksum = "8746739f11d39ce5ad5c2520a9b75285310dbfe78c541ccf832d38615765aec0"
 dependencies = [
  "bitflags",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["text-processing"]
 
 [dependencies]
 once_cell = "1.18.0"
-pulldown-cmark = { version = "0.10.0", default-features = false }
+pulldown-cmark = { version = "0.11", default-features = false }
 regex = "1.9.3"


### PR DESCRIPTION
Fixes issues from newly added `Event` variants ([`Event::DisplayMath`](https://docs.rs/pulldown-cmark/latest/pulldown_cmark/enum.Event.html#variant.DisplayMath) and [`Event::InlineMath`](https://docs.rs/pulldown-cmark/latest/pulldown_cmark/enum.Event.html#variant.InlineMath)) with no changes to actual implementation.