### PR TITLE
Bump pulldown-cmark to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8746739f11d39ce5ad5c2520a9b75285310dbfe78c541ccf832d38615765aec0"
+checksum = "4d31cbfcd94884c3a67ec210c83efb06cb43674043458b0ad59f6947f8462c23"
 dependencies = [
  "bitflags",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["text-processing"]
 
 [dependencies]
 once_cell = "1.18.0"
-pulldown-cmark = { version = "0.11", default-features = false }
+pulldown-cmark = { version = "0.12", default-features = false }
 regex = "1.9.3"


### PR DESCRIPTION
Fixes versioning issues from changes to `TagEnd`. No changes to implementation.